### PR TITLE
fixed: gcc compile error (explicit template specialization cannot have a storage class)

### DIFF
--- a/src/api/rvmparser.cpp
+++ b/src/api/rvmparser.cpp
@@ -104,7 +104,7 @@ inline T read_(std::istream& in)
 }
 
 template<>
-static Identifier& read_<Identifier>(std::istream& in, Identifier& res)
+inline Identifier& read_<Identifier>(std::istream& in, Identifier& res)
 {
     static char buf[12];
     auto chrs = res.chrs;


### PR DESCRIPTION
Hi,

just a minor fix so gcc can compile pmuc, could you pull the change.

thanks 
  gerrit

